### PR TITLE
chore: add VSCode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.defaultFormatter": "dprint.dprint",
+  "editor.tabSize": 2,
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.ts": "$(capture).*.ts",
+  },
+}


### PR DESCRIPTION
## Overview

Add VSCode workspace settings to ensure consistent development environment across contributors.

## Changes

- Add `.vscode/settings.json` with workspace configuration
- Set dprint as the default formatter
- Configure tab size to 2 spaces
- Enable file nesting for TypeScript files

## Test Instructions

1. Open the project in VSCode
2. Verify that dprint is used as the default formatter
3. Check that file nesting groups related `.ts` files together

## References

- [dprint VSCode extension](https://marketplace.visualstudio.com/items?itemName=dprint.dprint)