### PR TITLE
fix: exclude empty options from preparer config

### DIFF
--- a/src/preparer.ts
+++ b/src/preparer.ts
@@ -33,8 +33,8 @@ export class GhPagesPreparerPlugin
     const { branch, outDir } = config.options
 
     return Promise.resolve({
-      branch,
-      outDir,
+      ...(branch && { branch }),
+      ...(outDir && { outDir }),
     })
   }
 }


### PR DESCRIPTION
## Summary
- Fix preparer plugin to exclude empty string options from the generated config
- Prevent empty `branch` or `outDir` values from being written to `regconfig.json`

## Changes

```mermaid
graph LR
    A[User Input] --> B{branch/outDir empty?}
    B -->|Yes| C[Exclude from config]
    B -->|No| D[Include in config]
    C --> E[regconfig.json]
    D --> E
```

### Before
```typescript
return Promise.resolve({
  branch,  // Always included, even if empty string
  outDir,  // Always included, even if empty string
})
```

### After
```typescript
return Promise.resolve({
  ...(branch && { branch }),  // Only include if truthy
  ...(outDir && { outDir }),  // Only include if truthy
})
```

## Test plan
- [ ] Run `reg-suit init` and leave branch/outDir prompts empty
- [ ] Verify `regconfig.json` does not contain empty string values