### PR TITLE
ci: use PR number for VRT output directory

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -51,4 +51,5 @@ jobs:
       - name: Run reg-suit
         run: cd example && pnpm reg-suit run
         env:
+          VRT_OUTPUT_DIR: pr/${{ github.event.pull_request.number }}/vrt
           REG_NOTIFY_CLIENT_ID: ${{ secrets.REG_NOTIFY_CLIENT_ID }}

--- a/example/regconfig.json
+++ b/example/regconfig.json
@@ -12,8 +12,7 @@
     "reg-keygen-git-hash-plugin": {},
     "reg-publish-gh-pages-plugin": {
       "branch": "gh-pages",
-      "outDir": "pr/vrt",
-      "includeCommitHash": true
+      "outDir": "$VRT_OUTPUT_DIR"
     },
     "reg-notify-github-plugin": {
       "clientId": "$REG_NOTIFY_CLIENT_ID"


### PR DESCRIPTION
## Summary
- Use PR number in VRT output directory path instead of commit hash
- Make output directory configurable via environment variable

## Changes

```mermaid
graph LR
    A[PR #123] --> B[VRT_OUTPUT_DIR=pr/123/vrt]
    B --> C[regconfig.json]
    C --> D[gh-pages: pr/123/vrt/]
```

### Modified Files
- `.github/workflows/vrt.yml` - Add `VRT_OUTPUT_DIR` environment variable with PR number
- `example/regconfig.json` - Use `$VRT_OUTPUT_DIR` environment variable for dynamic path configuration

### Before
```json
{
  "outDir": "pr/vrt",
  "includeCommitHash": true
}
```
Output: `pr/vrt/<commit-hash>/`

### After
```json
{
  "outDir": "$VRT_OUTPUT_DIR"
}
```
Output: `pr/<pr-number>/vrt/`

## Benefits
- Cleaner URL structure with PR number instead of commit hash
- Easier to identify reports by PR number
- Environment variable allows flexible configuration per workflow

## Test plan
- [ ] Create a test PR and verify VRT output goes to `pr/<pr-number>/vrt/`
- [ ] Verify report URL uses correct PR number path