### PR TITLE
chore: add package description and keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reg-publish-gh-pages-plugin",
   "version": "0.0.1",
-  "description": "",
+  "description": "A reg-suit publisher plugin to deploy visual regression test reports to GitHub Pages",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "files": [
@@ -18,7 +18,11 @@
   },
   "keywords": [
     "reg",
-    "reg-suit-plugin"
+    "reg-suit",
+    "reg-suit-plugin",
+    "visual-regression",
+    "vrt",
+    "github-pages"
   ],
   "author": "KyoheiG3",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Add descriptive package description for npm registry
- Expand keywords for better discoverability

## Changes

### package.json

**Description:**
```
"description": "A reg-suit publisher plugin to deploy visual regression test reports to GitHub Pages"
```

**Keywords:**
```json
[
  "reg",
  "reg-suit",
  "reg-suit-plugin",
  "visual-regression",
  "vrt",
  "github-pages"
]
```

## Benefits
- Better package discoverability on npm
- Clear description helps users understand the package purpose
- Additional keywords improve search results for VRT-related queries

## Test plan
- [x] Verify package.json is valid JSON
- [ ] Check npm search results after publish