### PR TITLE
chore: prepare v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## v0.1.0
+
+Initial release of reg-publish-gh-pages-plugin.
+
+### Features
+
+- Add `GhPagesPublisherPlugin` for deploying VRT reports to GitHub Pages
+- Add `GhPagesPreparerPlugin` for interactive configuration via `reg-suit init`
+- Support dynamic URL generation based on repository information
+- Support deployment via git worktree for efficient branch management
+- Support environment variable expansion in options (`$VAR` syntax)
+- Auto-detect repository info from `GITHUB_REPOSITORY` env or git remote
+- Use `GITHUB_ACTOR` for commit author attribution
+- Add push retry with rebase on conflict
+
+### Configuration Options
+
+- `branch` - Target branch for deployment (optional, enables deployment when set)
+- `outDir` - Output directory on the target branch
+- `sourceDir` - Source directory to deploy (defaults to working directory)
+- `commitMessage` - Custom commit message
+- `includeCommitHash` - Include commit hash in output path
+
+### Documentation
+
+- Add comprehensive README with configuration examples
+- Add Japanese documentation (README.ja.md)
+- Add example project with Playwright screenshot workflow

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reg-publish-gh-pages-plugin",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A reg-suit publisher plugin to deploy visual regression test reports to GitHub Pages",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
## Summary
Prepare initial release v0.1.0 of reg-publish-gh-pages-plugin.

## Changes

### Version Bump
- Update `package.json` version from `0.0.1` to `0.1.0`

### CHANGELOG.md
Add comprehensive changelog documenting all features in the initial release:

#### Features
- `GhPagesPublisherPlugin` for deploying VRT reports to GitHub Pages
- `GhPagesPreparerPlugin` for interactive configuration
- Dynamic URL generation based on repository information
- Deployment via git worktree for efficient branch management
- Environment variable expansion in options (`$VAR` syntax)
- Auto-detect repository info from `GITHUB_REPOSITORY` or git remote
- `GITHUB_ACTOR` for commit author attribution
- Push retry with rebase on conflict

#### Configuration Options
- `branch` - Target branch for deployment
- `outDir` - Output directory on the target branch
- `sourceDir` - Source directory to deploy
- `commitMessage` - Custom commit message
- `includeCommitHash` - Include commit hash in output path

#### Documentation
- Comprehensive README with configuration examples
- Japanese documentation (README.ja.md)
- Example project with Playwright screenshot workflow

## Test plan
- [ ] Review CHANGELOG for accuracy
- [ ] Verify package.json version
- [ ] After merge, create GitHub release with tag `v0.1.0`
- [ ] Publish to npm