### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.2.0
+
+### Features
+
+- Add `reportPath` option for custom report URL configuration
+  - If starts with `http`, used as full URL
+  - Otherwise, used as path segment in the generated URL
+
 ## v0.1.0
 
 Initial release of reg-publish-gh-pages-plugin.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reg-publish-gh-pages-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A reg-suit publisher plugin to deploy visual regression test reports to GitHub Pages",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
## Overview

Prepare the v0.2.0 release with version bump and changelog update.

## Changes

- Bump version from 0.1.0 to 0.2.0 in package.json
- Add v0.2.0 section to CHANGELOG.md documenting the new `reportPath` option

## Test Instructions

1. Verify package.json version is set to 0.2.0
2. Verify CHANGELOG.md contains the v0.2.0 release notes
3. Run `npm test` to ensure all tests pass

## References

- Follows PR #12 which added the `reportPath` feature