### PR TITLE
fix: use git ls-remote for remote branch detection

### DIFF
--- a/src/git-deploy.ts
+++ b/src/git-deploy.ts
@@ -26,8 +26,9 @@ function escapeDoubleQuotes(str: string): string {
 
 function branchExists(branch: string): boolean {
   try {
-    exec(`git rev-parse --verify origin/${branch}`)
-    return true
+    // Check if branch exists on remote without fetching
+    const result = exec(`git ls-remote --heads origin ${branch}`)
+    return result.length > 0
   } catch {
     return false
   }
@@ -51,6 +52,8 @@ export function deployToGitHubPages(options: DeployOptions): void {
     }
 
     if (branchExists(branch)) {
+      // Fetch the branch to ensure we have the latest refs
+      exec(`git fetch origin ${branch}`)
       // Add worktree for existing branch
       exec(`git worktree add ${worktreeDir} origin/${branch}`)
       exec(`git checkout -B ${branch}`, worktreeDir)


### PR DESCRIPTION
## Overview

Fix remote branch detection to use `git ls-remote` instead of `git rev-parse --verify`. This change improves reliability when checking if a branch exists on the remote, especially in CI environments where local refs may not be up to date.

## Changes

- Replace `git rev-parse --verify origin/<branch>` with `git ls-remote --heads origin <branch>` for branch existence check
- Add `git fetch origin <branch>` before adding worktree when branch exists to ensure refs are up to date
- Handle `git ls-remote` command failures gracefully by treating them as "branch not exists" (creates orphan branch)
- Update tests to reflect the new command usage and add test case for network error handling

## Test Instructions

1. Run the test suite:
   ```bash
   npm test
   ```

2. Verify the following scenarios work correctly:
   - Deploy to an existing gh-pages branch
   - Deploy to a new gh-pages branch (orphan creation)
   - Handle network errors gracefully

3. Manual testing in a repository:
   ```bash
   # Test with existing branch
   reg-suit run

   # Test with non-existing branch (should create orphan)
   reg-suit run  # on a repo without gh-pages branch
   ```

## References

- Improves reliability in CI environments where local git refs may be stale
- Graceful error handling prevents deployment failures due to network issues