### PR TITLE
chore: prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.2.1
+
+### Bug Fixes
+
+- Use `git ls-remote` for remote branch detection instead of `git rev-parse`
+  - Improves reliability in CI environments where local refs may be stale
+  - Gracefully handles network errors by creating orphan branch
+
 ## v0.2.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reg-publish-gh-pages-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A reg-suit publisher plugin to deploy visual regression test reports to GitHub Pages",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
## Overview

Prepare the v0.2.1 patch release with version bump and changelog update.

## Changes

- Bump version from 0.2.0 to 0.2.1 in package.json
- Add v0.2.1 section to CHANGELOG.md documenting the bug fix:
  - Use `git ls-remote` for remote branch detection instead of `git rev-parse`
  - Improves reliability in CI environments where local refs may be stale
  - Gracefully handles network errors by creating orphan branch

## Test Instructions

1. Verify package.json version is set to 0.2.1
2. Verify CHANGELOG.md contains the v0.2.1 release notes
3. Run `npm test` to ensure all tests pass

## References

- Follows PR #14 which fixed the remote branch detection issue