### PR TITLE
ci: switch cleanup-pr to official deploy-pages action

### DIFF
--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -35,6 +35,5 @@ jobs:
           path: .
 
       - name: Deploy to GitHub Pages
-        uses: ./.github/actions/deploy-pages
-        with:
-          artifact_id: ${{ steps.upload.outputs.artifact_id }}
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Overview
Replace the custom deploy-pages action with the official `actions/deploy-pages@v4.0.5` action in the cleanup-pr workflow.

## Changes
- Remove usage of custom `./.github/actions/deploy-pages` action
- Switch to official `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` (v4.0.5)
- Remove unnecessary `artifact_id` input parameter (official action handles this automatically)
- Add deployment step id for potential future reference

## Test Instructions
1. Create a PR and push changes to trigger the workflow
2. Close the PR to trigger the cleanup-pr workflow
3. Verify that GitHub Pages deployment completes successfully

## References
- [actions/deploy-pages](https://github.com/actions/deploy-pages)