### PR TITLE
docs: add GitHub Pages deployment source documentation

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -56,6 +56,8 @@ jobs:
           VRT_OUTPUT_DIR: pr/${{ github.event.pull_request.number }}
           REG_NOTIFY_CLIENT_ID: ${{ secrets.REG_NOTIFY_CLIENT_ID }}
 
+      # The following deployment steps are required when GitHub Pages
+      # "Build and deployment" Source is set to "GitHub Actions"
       - name: Checkout gh-pages
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -68,6 +70,7 @@ jobs:
         with:
           path: gh-pages-dir
 
+      # Deploy to GitHub Pages similar to actions/deploy-pages
       - name: Deploy to GitHub Pages
         uses: ./.github/actions/deploy-pages
         with:

--- a/README.ja.md
+++ b/README.ja.md
@@ -173,6 +173,50 @@ jobs:
 
 - `contents: write` - gh-pages ブランチへのプッシュに必要
 
+### GitHub Pages デプロイソース
+
+GitHub Pages にはリポジトリ設定で2つのデプロイソースオプションがあります：
+
+#### Deploy from a branch（デフォルト）
+
+「Build and deployment」の Source を「Deploy from a branch」に設定している場合、gh-pages ブランチへのプッシュ後に非同期でデプロイされます。追加の設定は不要です。
+
+#### GitHub Actions
+
+「Build and deployment」の Source を「GitHub Actions」に設定している場合、以下の権限と `reg-suit run` の後に追加のステップが必要です：
+
+**追加で必要な権限：**
+```yaml
+permissions:
+  contents: write
+  id-token: write
+  pages: write
+```
+
+**`reg-suit run` の後に追加するステップ：**
+```yaml
+      # 'gh-pages' は実際の設定に合わせたブランチ名に置き換えてください
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-dir
+
+      - name: Upload pages artifact
+        id: upload
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: gh-pages-dir
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+**GitHub Actions デプロイの利点：**
+- ブランチベースのデプロイより実行時間が短い
+- デプロイの完了が CI ワークフローで確認できる
+
 ## 動作の仕組み
 
 1. **リポジトリ検出** - `GITHUB_REPOSITORY` 環境変数または git remote URL から owner/repo を取得

--- a/README.md
+++ b/README.md
@@ -173,6 +173,50 @@ jobs:
 
 - `contents: write` - Required for pushing to the gh-pages branch
 
+### GitHub Pages Deployment Source
+
+GitHub Pages has two deployment source options in repository settings:
+
+#### Deploy from a branch (default)
+
+When "Build and deployment" Source is set to "Deploy from a branch", deployment happens asynchronously after pushing to the gh-pages branch. No additional configuration is needed.
+
+#### GitHub Actions
+
+When "Build and deployment" Source is set to "GitHub Actions", you need to add the following permissions and steps after `reg-suit run`:
+
+**Additional permissions required:**
+```yaml
+permissions:
+  contents: write
+  id-token: write
+  pages: write
+```
+
+**Steps to add after `reg-suit run`:**
+```yaml
+      # Replace 'gh-pages' with your configured branch name
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-dir
+
+      - name: Upload pages artifact
+        id: upload
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: gh-pages-dir
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+**Benefits of GitHub Actions deployment:**
+- Faster deployment compared to branch-based deployment
+- Deployment completion is visible in the CI workflow
+
 ## How It Works
 
 1. **Repository Detection** - Detects owner/repo from `GITHUB_REPOSITORY` environment variable or git remote URL


### PR DESCRIPTION
## Overview
Add documentation explaining the two GitHub Pages deployment source options to help users configure their workflows correctly.

## Changes
- Add "GitHub Pages Deployment Source" section to README.md and README.ja.md
- Document "Deploy from a branch" (default, asynchronous deployment)
- Document "GitHub Actions" deployment with required permissions and workflow steps
- Add comments to vrt.yml explaining the deployment steps
- Include note about replacing branch name with configured value

## Test Instructions
1. Review the documentation in README.md and README.ja.md
2. Verify the workflow example is correct and follows best practices
3. Check that both English and Japanese versions are consistent

## References
- [GitHub Pages documentation](https://docs.github.com/en/pages)
- [actions/deploy-pages](https://github.com/actions/deploy-pages)
- [actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact)