### PR TITLE
chore: prepare v0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.2.2
+
+### Bug Fixes
+
+- Unset git config (user.name, user.email) after deployment to prevent persisting in main repository
+
+### Documentation
+
+- Add GitHub Pages deployment source documentation (English and Japanese)
+- Document "Deploy from a branch" and "GitHub Actions" deployment options
+
+### Infrastructure
+
+- Add `eslint-plugin-simple-import-sort` for consistent import ordering
+
 ## v0.2.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reg-publish-gh-pages-plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A reg-suit publisher plugin to deploy visual regression test reports to GitHub Pages",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
## Overview
Prepare the v0.2.2 release with version bump and changelog updates.

## Changes
- Bump version from 0.2.1 to 0.2.2 in package.json
- Update CHANGELOG.md with v0.2.2 release notes including:
  - Bug fix: unset git config after deployment
  - Documentation: GitHub Pages deployment source options
  - Infrastructure: eslint-plugin-simple-import-sort

## Test Instructions
1. Review the CHANGELOG.md for accuracy
2. Verify package.json version is correct
3. After merge, create a GitHub release with tag v0.2.2

## References
- #20 - docs: add GitHub Pages deployment source documentation
- #21 - fix: unset git config after deployment and add eslint import sorting